### PR TITLE
readme: improve installation options

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,11 @@ Immutable moment.js with composable functions and partial application of data
 ## Installation
 
 ```
-$ npm install momento
+$ yarn add momento
+```
+or
+```
+$ npm install momento --save
 ```
 
 ## Example with Ramda pipe


### PR DESCRIPTION
yarn > npm, also adds `--save` because npm < 5 won't add the package in package.json